### PR TITLE
Removing the CSS float on the main content

### DIFF
--- a/eme/styles/demo.css
+++ b/eme/styles/demo.css
@@ -18,10 +18,6 @@
     outline: none;
 }
 
-.main.section{
-    float:left;
-}
-
 div.controls {
     width: 100%;
 }


### PR DESCRIPTION
Avoids frame server mode so we display protected content properly. It
was not needed.
