### PR TITLE
Remove redundant `type` attributes

### DIFF
--- a/@supports/index.html
+++ b/@supports/index.html
@@ -6,8 +6,8 @@
 	<meta name="description" content="Test Whether Certain CSS Properties and Values are Supported">
 	<meta name="keywords" content="CSS, css, @supports, feature testing">
 	<meta name="author" content="AaronGustafson">
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-	<link rel="stylesheet" type="text/css" href="styles/demo.css">
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="styles/demo.css">
 </head>
 
 <body>

--- a/analyzeperformance/index.html
+++ b/analyzeperformance/index.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="A set of example pages to use for analyzing performance"/>
 	<meta name="keywords" content="performance, profiling"/>
 	<meta name="author" content="toddreifsteck"/>
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
 </head>
 <body>
 

--- a/analyzeperformance/topdownblog/topdownblog.html
+++ b/analyzeperformance/topdownblog/topdownblog.html
@@ -6,8 +6,8 @@
 	<meta name="og:title" content="Poor performance example"/>
 	<meta name="description" content="Test profiling skills on this poorly performing page"/>
 	<meta name="keywords" content="performance, profile, topdown"/>
-	<link href='https://fonts.googleapis.com/css?family=Oswald:400,300' rel='stylesheet' type='text/css'>
-	<link rel="stylesheet" type="text/css" href="styles/topdown.css"/>
+	<link href='https://fonts.googleapis.com/css?family=Oswald:400,300' rel='stylesheet'>
+	<link rel="stylesheet" href="styles/topdown.css"/>
 </head>
 <body>
 	<div id="header">
@@ -85,6 +85,6 @@
 	<div id="footer">
 		<p>Thanks for checking out this demo.</p>
 	</div>
-	<script type="text/javascript" src="scripts/topdown.js" />
+	<script src="scripts/topdown.js"></script>
 </body>
 </html>

--- a/audiomixer/index.html
+++ b/audiomixer/index.html
@@ -7,8 +7,8 @@
 	<meta name="keywords" content="Media, web, audio"/>
 	<meta name="author" content="aliams"/>
 	<meta name="viewport" content="width=device-width"/>
-	<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>
@@ -85,10 +85,10 @@
 		</section>
 	</div>
 
-	<script type="text/javascript" src="//code.jquery.com/jquery-2.1.4.min.js"></script>
-	<script type="text/javascript" src="scripts/ui.js"></script>
-	<script type="text/javascript" src="scripts/audio.js"></script>
-	<script type="text/javascript" src="scripts/db.js"></script>
+	<script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+	<script src="scripts/ui.js"></script>
+	<script src="scripts/audio.js"></script>
+	<script src="scripts/db.js"></script>
 
 </body>
 </html>

--- a/betafish/Default.html
+++ b/betafish/Default.html
@@ -6,8 +6,8 @@
         <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>BetaFishIE</title>
         <meta name="description" content="HTML5 Fish, Touch and Performance Benchmark, HTML5 Test" />
-        <link rel="image_src" href="../../Views/Homepage/Icons/BetaFishIE.png" />        
-        <link rel="stylesheet" type="text/css" href="BetaFishIE.css" />
+        <link rel="image_src" href="../../Views/Homepage/Icons/BetaFishIE.png" />
+        <link rel="stylesheet" href="BetaFishIE.css" />
         <meta name="t_omni_demopage" content="1" />
     </head> 
     <body>
@@ -64,9 +64,9 @@
             <div id="ButtonToggleSwimming" title="Pause (P)" onclick="ToggleFishSwimming();"></div>
             <div id="ButtonReset" title="Reset (R)" onclick="ResetDemo();"></div>
         </div>
-        <script type="text/javascript" src="Script/Settings.js"></script>
-        <script type="text/javascript" src="Script/Performance.js"></script>
-        <script type="text/javascript" src="../../includes/script/TestDriveCommon.js"></script>
-		<script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+        <script src="Script/Settings.js"></script>
+        <script src="Script/Performance.js"></script>
+        <script src="../../includes/script/TestDriveCommon.js"></script>
+		<script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
     </body>
 </html>

--- a/blobbuilder/index.html
+++ b/blobbuilder/index.html
@@ -6,8 +6,8 @@
 	<meta name="description" content="Create files dynamically on the client side using JavaScript and the Blob API"/>
 	<meta name="og:title" content="Blob Bop"/>
 	<meta name="keywords" content="misc, blob, blobbuilder, javascript, svg"/>
-	<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>
@@ -300,7 +300,7 @@
 	</div>
 </section>
 
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 
 </html>

--- a/chalkboard/Default.html
+++ b/chalkboard/Default.html
@@ -5,12 +5,12 @@
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
         <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>Chalkboard HTML5 Benchmark</title>
-        <meta name="description" content="HTML5 and SVG Performance Benchmark" />        
-        <link rel="stylesheet" type="text/css" href="Chalkboard.css" />        
+        <meta name="description" content="HTML5 and SVG Performance Benchmark" />
+        <link rel="stylesheet" href="Chalkboard.css" />
         <meta name="t_omni_demopage" content="1" />
     </head>
     <body onload="Initialize()">
-        <div id="DemoScreenreaderText">Thanks for checking out this Internet Explorer 10 Test Drive demo. This demo uses animation techniques to move (pan, zoom, and scale) an image around on the screen. The faster your browser and the smoother the chalkboard will feel.</div>        
+        <div id="DemoScreenreaderText">Thanks for checking out this Internet Explorer 10 Test Drive demo. This demo uses animation techniques to move (pan, zoom, and scale) an image around on the screen. The faster your browser and the smoother the chalkboard will feel.</div>
         <img id="EmptyChalkboard" src="Images/EmptyChalkboard.svg" />
         <img id="Chalkboard" src="Images/Chalkboard.svg" />
         <div id="Intro">
@@ -26,9 +26,9 @@
             </div>
         </div>
         <audio id="Audio" src="Audio/Whoosh2.mp3"></audio>
-        <script type="text/javascript" src="Script/Benchmark.js"></script>
-        <script type="text/javascript" src="../Includes/Script/FeatureDetectAudio.js"></script>
-        <script type="text/javascript" src="../includes/script/TestDriveCommon.js"></script>
-        <script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+        <script src="Script/Benchmark.js"></script>
+        <script src="../Includes/Script/FeatureDetectAudio.js"></script>
+        <script src="../includes/script/TestDriveCommon.js"></script>
+        <script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
     </body>
 </html>

--- a/chess/index.html
+++ b/chess/index.html
@@ -4,8 +4,8 @@
         <title>Chess</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width">
-        <link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-        <link rel="stylesheet" type="text/css" href="css/app.css">
+        <link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+        <link rel="stylesheet" href="css/app.css">
     </head>
     <body class="chess">
 

--- a/coloringbook/animals.html
+++ b/coloringbook/animals.html
@@ -5,8 +5,8 @@
     <title>Web Note Coloring Book</title>
     <meta name="description" content="Web Note is a new feature of Microsoft Edge that helps you write, draw, make notes and share web pages.">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-    <link rel="stylesheet" type="text/css" href="styles/demo.css">
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+    <link rel="stylesheet" href="styles/demo.css">
 </head>
 
 <body>

--- a/coloringbook/christmas.html
+++ b/coloringbook/christmas.html
@@ -5,8 +5,8 @@
     <title>Web Note Coloring Book</title>
     <meta name="description" content="Web Note is a new feature of Microsoft Edge that helps you write, draw, make notes and share web pages.">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-    <link rel="stylesheet" type="text/css" href="styles/demo.css">
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+    <link rel="stylesheet" href="styles/demo.css">
 </head>
 
 <body>

--- a/coloringbook/index.html
+++ b/coloringbook/index.html
@@ -5,8 +5,8 @@
     <title>Web Note Coloring Book</title>
     <meta name="description" content="Web Note is a new feature of Microsoft Edge that helps you write, draw, make notes and share web pages.">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-    <link rel="stylesheet" type="text/css" href="styles/demo.css">
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+    <link rel="stylesheet" href="styles/demo.css">
 </head>
 
 <body>

--- a/compatinspector/index.html
+++ b/compatinspector/index.html
@@ -8,7 +8,7 @@
 				your site.">
 	<meta name="keywords" content="debug, compatinspector">
 	<meta name="author" content="MSEdge">
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
 </head>
 <body>
 

--- a/css3filters/index.html
+++ b/css3filters/index.html
@@ -5,8 +5,8 @@
 	<meta name="description" content="Learn how to use CSS3 filters. "/>
 	<meta name="keywords" content="CSS, css3 filters"/>
 	<meta name="author" content="sayar"/>
-	<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>
@@ -163,7 +163,7 @@
 	</div>
 </section>
 
-<script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.3.min.js"></script>
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.3.min.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 </html>

--- a/css3mediaqueries/index.html
+++ b/css3mediaqueries/index.html
@@ -7,8 +7,8 @@
     <meta name="description" content="Introduced in IE9, CSS3 Media queries enable you to style a page based on different display surface factors such as width, height, orientation, resolution, etc." />
     <meta name="keywords" content="css3, media query listeners" />
     <meta name="og:title" content="Title of the demo in the website" />
-	<link rel="stylesheet" type="text/css" href="./styles/demotemplate.css" />
-	<link rel="stylesheet" type="text/css" href="./styles/demo.css" /> </head>
+	<link rel="stylesheet" href="./styles/demotemplate.css" />
+	<link rel="stylesheet" href="./styles/demo.css" /> </head>
 
 <body>
     <div class="container">
@@ -170,7 +170,7 @@ function mediaSizeChange(mediaQueryList)
             </div>
         </div>
     </div>
-	<script type="text/javascript" src="scripts/Demo.js"></script>
+	<script src="scripts/Demo.js"></script>
 </body>
 
 </html>

--- a/editingpasteimage/index.html
+++ b/editingpasteimage/index.html
@@ -6,8 +6,8 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<meta name="description" content="IE11 Paste Local Image Test Drive Demo" />
 	<title>Pasting Local Images Demo</title>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css" />
-	<link rel="stylesheet" type="text/css" href="styles/demotemplate.css" />
+	<link rel="stylesheet" href="styles/demo.css" />
+	<link rel="stylesheet" href="styles/demotemplate.css" />
 	<meta name="keywords" content="input" />
 	<meta name="og:title" content="IE11 Paste Local Image Test Drive Demo" />
 </head>

--- a/eme/index.html
+++ b/eme/index.html
@@ -10,8 +10,8 @@
     <meta name="keywords" content="Media, Playready, Encrypted Media Extensions, EME, DRM, Cacheless XMLHttpRequests, Touch, Video, Bitrate, Protected content, Widevine"
     />
     <meta name="author" content="InternetExplorer" />
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-    <link rel="stylesheet" type="text/css" href="styles/demo.css" />
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+    <link rel="stylesheet" href="styles/demo.css" />
 </head>
 
 <body>
@@ -86,7 +86,7 @@
             </div>
         </section>
     </article>
-    <script type="text/javascript" src="scripts/demo.js"></script>
+    <script src="scripts/demo.js"></script>
 </body>
 
 </html>

--- a/familysearch/index.html
+++ b/familysearch/index.html
@@ -5,8 +5,8 @@
 	<meta name="description" content=""/>
 	<meta name="keywords" content="Misc, safe search"/>
 	<meta name="author" content="dwalp"/>
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>

--- a/fishbowlie/index.html
+++ b/fishbowlie/index.html
@@ -8,7 +8,7 @@
 
         <meta name="description" content="Find your innner fish." />
         <link rel="shortcut icon" href="../Includes/Image/FavIcon.ico" />
-        <link rel="stylesheet" type="text/css" href="Fishbowl.css" />        
+        <link rel="stylesheet" href="Fishbowl.css" />
         <meta name="t_omni_demopage" content="1" />
     </head>
     <body onload="Initialize()">
@@ -58,19 +58,19 @@
             <div id="chkFPSMeter" class="Control Enabled" onclick="fpsMeter.ToggleVisibility();">FPS</a></div>
             <div id="chkFPSNeedle" class="Control Enabled" onclick="fpsMeter.ToggleNeedleVisibility();">Needle</a></div>
         </div>
-        <script type="text/javascript" src="Script/Application.js"></script>
-        <script type="text/javascript" src="Script/LoadingCover.js"></script>
-        <script type="text/javascript" src="Script/Resources.js"></script>
-        <script type="text/javascript" src="Script/Water.js"></script>
-        <script type="text/javascript" src="Script/FishBowl.js"></script>
-        <script type="text/javascript" src="Script/Fish.js"></script>
-        <script type="text/javascript" src="Script/Frame.js"></script>
-        <script type="text/javascript" src="Script/Keyboard.js"></script>
-        <script type="text/javascript" src="Script/Logo.js"></script>
-        <script type="text/javascript" src="Script/FPSMeter.js"></script>
-        <script type="text/javascript" src="Script/Performance.js"></script>        
-        <script type="text/javascript" src="../includes/script/TestDriveCommon.js"></script>
-        <script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+        <script src="Script/Application.js"></script>
+        <script src="Script/LoadingCover.js"></script>
+        <script src="Script/Resources.js"></script>
+        <script src="Script/Water.js"></script>
+        <script src="Script/FishBowl.js"></script>
+        <script src="Script/Fish.js"></script>
+        <script src="Script/Frame.js"></script>
+        <script src="Script/Keyboard.js"></script>
+        <script src="Script/Logo.js"></script>
+        <script src="Script/FPSMeter.js"></script>
+        <script src="Script/Performance.js"></script>
+        <script src="../includes/script/TestDriveCommon.js"></script>
+        <script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
     </body>
 
 </html>

--- a/fishietank/index.html
+++ b/fishietank/index.html
@@ -5,9 +5,9 @@
 
     <title>FishIE Tank</title>
     <meta name="description" content="Thanks for checking out this site. This demo uses the canvas element to draw fish swimming in a fish tank." />
-    <script type="text/javascript" src="../Includes/Script/FeatureDetectCanvas.js"></script>
-    <script type="text/javascript" src="./scripts/fpsometer.js"></script>
-    <link rel="stylesheet" type="text/css" href="./styles/fpsometer.css" />
+    <script src="../Includes/Script/FeatureDetectCanvas.js"></script>
+    <script src="./scripts/fpsometer.js"></script>
+    <link rel="stylesheet" href="./styles/fpsometer.css" />
     <style>
         #canvas1
         {
@@ -326,8 +326,8 @@
     <div class="hidden" tabIndex="-1">Thanks for checking out this site. This demo uses the canvas element to draw fish swimming in a fish tank. The FPS count tells you how many frames per second the browser is able to draw. If you add or remove fish, the frames per second will go up or down depending on how much work the browser is able to do each frame.  
         The UI is primarliy driven through Javascript and Canvas. The purpose of these demos is to convey a concept and not intended to be used as a best practice for web development. 
         It’s not the cleanest code, and in some places we took shortcuts to get more demos to you. Enjoy! </div> <!--description for screen readers-->
-    
-    <script type="text/javascript" src="../includes/script/TestDriveCommon.js"></script>
-    <script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>	
+
+    <script src="../includes/script/TestDriveCommon.js"></script>
+    <script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
 </body>
 </html>

--- a/html5forms/autofocus.html
+++ b/html5forms/autofocus.html
@@ -4,8 +4,8 @@
     <meta name="description" content="IE10 Test Drive Demo"/>
     <meta name="t_omni_demopage" content="1"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-    <link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+    <link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>
 <div id="demo-wrapper">

--- a/html5forms/index.html
+++ b/html5forms/index.html
@@ -7,8 +7,8 @@
           content="HTML5 Forms offers two major advantages over previous versions: new input types and built in validation. The form below is an example cake order form that utilizes validation and new input types."/>
     <meta name="keywords" content="input, forms, html5, javascript"/>
     <meta name="og:title" content="HTML5 Forms"/>
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-    <link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+    <link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>
 <div id="demo-wrapper">
@@ -428,6 +428,6 @@ function displayErrorExperience(form) {
 		</div>
 	</div>
 </div>
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 </html>

--- a/letitsnow/Default.html
+++ b/letitsnow/Default.html
@@ -45,22 +45,22 @@
     </div>
     <audio id="music" src="./res/LetItSnowShort.mp3" loop autoplay ></audio>
     <!-- common libraries -->
-    <script type="text/javascript" src="./js/classes.js"></script>
-    <script type="text/javascript" src="./js/touch.js"></script>
-    <script type="text/javascript" src="./js/animation.js"></script>
-    <script type="text/javascript" src="./js/gfx.js"></script>
+    <script src="./js/classes.js"></script>
+    <script src="./js/touch.js"></script>
+    <script src="./js/animation.js"></script>
+    <script src="./js/gfx.js"></script>
     <!-- holidays postcard -->
-    <script type="text/javascript" src="./js/postcard.js"></script>
+    <script src="./js/postcard.js"></script>
     <!-- stars and snowflakes -->
-    <script type="text/javascript" src="./js/snowflakes.js"></script>
+    <script src="./js/snowflakes.js"></script>
     <!-- system information -->
-    <script type="text/javascript" src="./js/systemInformation.js"></script>
+    <script src="./js/systemInformation.js"></script>
     <!-- gradient animation -->
-    <script type="text/javascript" src="./js/gradient.js"></script>
+    <script src="./js/gradient.js"></script>
     <!-- UI and initialization code -->
-    <script type="text/javascript" src="./js/default.js"></script>
+    <script src="./js/default.js"></script>
     <!-- testdrive standard -->
-    <script type="text/javascript" src="../../Includes/Script/TestDriveCommon.js"></script>
-	<script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>    
+    <script src="../../Includes/Script/TestDriveCommon.js"></script>
+	<script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
 </body>
 </html>

--- a/mandelbrot/index.html
+++ b/mandelbrot/index.html
@@ -9,8 +9,8 @@
 	<title>Calculate Mandelbrot using WebWorkers on your HTML5 browser</title>
 	<meta name="keywords"
 		  content="performance, webworkers, javascript, html5, canvas, requestanimationframe, demo, es5, ecmascript"/>
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-	<link rel="stylesheet" type="text/css" href="styles/demo.css">
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="styles/demo.css">
 </head>
 
 <body>
@@ -71,7 +71,7 @@
 		</div>
 	</section>
 
-	<script type="text/javascript" src="./scripts/demo.js"></script>
+	<script src="./scripts/demo.js"></script>
 
 </body>
 

--- a/math/index.html
+++ b/math/index.html
@@ -5,8 +5,8 @@
 	<meta name="description" content=""/>
 	<meta name="keywords" content="JavaScript, es6, ecmascript, math, expm1, log1p"/>
 	<meta name="author" content="bterlson"/>
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>
 

--- a/mazesolver/Default.html
+++ b/mazesolver/Default.html
@@ -6,13 +6,13 @@
 		<title>CSS Layout Performance Test</title>
 		<meta name="description" content="IE9 Test Drive Demo" />
 		<meta name="t_omni_demopage" content="1" /><meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<link rel="stylesheet" type="text/css" href="../Includes/Styles/BaseStyles.css" />
-        <link rel="stylesheet" type="text/css" href="../Includes/Styles/ReturnAndShareControls.css" />
+		<link rel="stylesheet" href="../Includes/Styles/BaseStyles.css" />
+        <link rel="stylesheet" href="../Includes/Styles/ReturnAndShareControls.css" />
 		<link rel="shortcut icon" href="../Includes/Image/FavIcon.ico" />
-        <link rel="stylesheet" type="text/css" href="maze.css" />
-        <script type="text/javascript" src="../Includes/script/BrowserInfo.js"></script>
-		<script type="text/javascript" src="seedrandom.js" ></script>
-        <script type="text/javascript" src="maze.js" ></script>
+        <link rel="stylesheet" href="maze.css" />
+        <script src="../Includes/script/BrowserInfo.js"></script>
+		<script src="seedrandom.js" ></script>
+        <script src="maze.js" ></script>
     </head>
     <body onload="initialize()">
         <div id="ReturnAndShareControls"></div>
@@ -65,7 +65,7 @@
 					HTML element. How quickly a browser can process that change determines how quickly the maze is completed. Designed from the ground up for speed, Internet Explorer 9's layout engine scales well even to large mazes.</p>
 				</div>
 		</div>
-		<script type="text/javascript" src="../Includes/Script/TestDriveCommon.js"></script>
-        <script type="text/javascript" src="../Includes/Script/ReturnAndShareControls.js"></script>
+		<script src="../Includes/Script/TestDriveCommon.js"></script>
+        <script src="../Includes/Script/ReturnAndShareControls.js"></script>
     </body>
 </html>

--- a/microphone/index.html
+++ b/microphone/index.html
@@ -6,8 +6,8 @@
 	<meta name="description" content=""/>
 	<meta name="keywords" content="Media, webaudio, getusermedia"/>
 	<meta name="author" content="jdsmith3000"/>
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>
@@ -95,8 +95,8 @@
 		</div>
 	</section>
 
-	<script type="text/javascript" src="scripts/recorder.js"></script>
-	<script type="text/javascript" src="scripts/demo.js"></script>
+	<script src="scripts/recorder.js"></script>
+	<script src="scripts/demo.js"></script>
 
 </body>
 </html>

--- a/musiclounge/index.html
+++ b/musiclounge/index.html
@@ -6,7 +6,7 @@
 		<meta name="description" content="Music Lounge is an interactive demo that showcase WebGL audio positioning within a minimalistic UI based on babylon.js" />
 		<meta name="keywords" content="Graphics, webgl, webaudio, pointer events" />
 		<meta name="author" content="deltakosh, meulta, davrous" />
-		<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css" />
+		<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css" />
 		<link href="styles/demo.css" rel="stylesheet" />
 	</head>
 	<body>

--- a/particleacceleration/index.html
+++ b/particleacceleration/index.html
@@ -29,8 +29,8 @@
 	</div>
 	<canvas id="performance-canvas"></canvas>
 </div>
-<script type="text/javascript" src="scripts/demo.js"></script>
-<script type="text/javascript" src="scripts/performance.js"></script>
-<script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+<script src="scripts/demo.js"></script>
+<script src="scripts/performance.js"></script>
+<script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
 </body>
 </html>

--- a/penguinmark/Default.html
+++ b/penguinmark/Default.html
@@ -5,10 +5,10 @@
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
         <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>PenguinMark</title>
-        <meta name="description" content="HTML5 Penguins, Performance, Web Benchmark, HTML5 Test" />        
-        <link rel="stylesheet" type="text/css" href="PenguinMark.css" />
+        <meta name="description" content="HTML5 Penguins, Performance, Web Benchmark, HTML5 Test" />
+        <link rel="stylesheet" href="PenguinMark.css" />
         <meta name="t_omni_demopage" content="1" />
-    </head> 
+    </head>
     <body>
         <div id="DemoScreenreaderText">Thanks for checking out this Internet Explorer Test Drive demo. This demo uses HTML5 and CSS features, including animations, transforms, canvas, callbacks, WOFF Fonts, power efficiency, touch, independent animation, smart fixed position elements, and more to provide an interactive Penguin loving experience this holiday season. Benchmarks are random and this TestDrive is no different. Enjoy!</div>
         <div id="Scene">
@@ -71,14 +71,14 @@
             <source src="Audio/Track.mp3" type="audio/mp3">
             <source src="Audio/Track.wav" type="audio/wav">
         </audio>
-        <script type="text/javascript" src="Script/Application.js"></script>
-        <script type="text/javascript" src="Script/Characters.js"></script>
-        <script type="text/javascript" src="Script/Keyboard.js"></script>
-        <script type="text/javascript" src="Script/Performance.js"></script>
-        <script type="text/javascript" src="Script/Snowflake.js"></script>
-        <script type="text/javascript" src="Script/Snowstorm.js"></script>
-        <script type="text/javascript" src="Script/Support.js"></script>
-        <script type="text/javascript" src="../../Includes/Script/TestDriveCommon.js"></script>
-		<script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+        <script src="Script/Application.js"></script>
+        <script src="Script/Characters.js"></script>
+        <script src="Script/Keyboard.js"></script>
+        <script src="Script/Performance.js"></script>
+        <script src="Script/Snowflake.js"></script>
+        <script src="Script/Snowstorm.js"></script>
+        <script src="Script/Support.js"></script>
+        <script src="../../Includes/Script/TestDriveCommon.js"></script>
+		<script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
     </body>
 </html>

--- a/photocapture/index.html
+++ b/photocapture/index.html
@@ -8,8 +8,8 @@
                                       to capture photos from webcam video streams through a canvas."/>
     <meta name="keywords" content="Media, webcam, media, capture, photo, canvas"/>
     <meta name="author" content="shijuns"/>
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-    <link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+    <link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>
@@ -74,7 +74,7 @@
     </section>
 
     <script src="//webrtc.github.io/adapter/adapter-0.2.3.js"></script>
-    <script type="text/javascript" src="scripts/demo.js"></script>
+    <script src="scripts/demo.js"></script>
 
 </body>
 </html>

--- a/picture/index.html
+++ b/picture/index.html
@@ -6,8 +6,8 @@
 	<meta name="description" content="Show how to enhance your example with responsive images">
 	<meta name="keywords" content="picture, srcset, sizes, responsive images">
 	<meta name="author" content="gregwhitworth">
-	<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css">
+	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css">
 </head>
 
 <body>

--- a/readingview/index.html
+++ b/readingview/index.html
@@ -19,8 +19,8 @@
 
 <body aria-haspopup="false">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/styles/shThemeDefault.min.css"
-      rel="stylesheet" type="text/css"/>
-<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+      rel="stylesheet" />
+<link rel="stylesheet" href="styles/demo.css"/>
 <div class="container">
     <div id="banner">
         <h1 class="title">
@@ -252,9 +252,9 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/scripts/shAutoloader.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/scripts/shBrushJScript.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/scripts/shBrushXml.min.js"></script>
-<script type="text/javascript" src="scripts/data.js"></script>
-<script type="text/javascript" src="scripts/utils.js"></script>
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="scripts/data.js"></script>
+<script src="scripts/utils.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 
 </html>

--- a/setimmediatesorting/index.html
+++ b/setimmediatesorting/index.html
@@ -5,8 +5,8 @@
 		<meta name="keywords" content="performance, settimeout, setimmediate, yielding, javascript, es5, ecmascript"/>
 		<meta name="og:title" content="JavaScript yielding"/>
 		<title>Efficient Script Yielding in JavaScript</title>
-		<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-		<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+		<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+		<link rel="stylesheet" href="styles/demo.css"/>
 	</head>
 
 	<body>
@@ -136,6 +136,6 @@
 			</div>
 		</section>
 
-		<script type="text/javascript" src="scripts/demo.js"></script>
+		<script src="scripts/demo.js"></script>
 	</body>
 </html>

--- a/speechsynthesis/index.html
+++ b/speechsynthesis/index.html
@@ -6,7 +6,7 @@
 	<meta name="description" content="Enter text and play it back as speech with different voices and settings">
 	<meta name="keywords" content="speech, synthesis, text-to-speech, SSML">
 	<meta name="author" content="jdsmith3000, ststimac, stevebe">
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
 	<link rel="stylesheet" href="styles/style.css">
 </head>
 <body>
@@ -54,6 +54,6 @@
 	</div>
 	<div id="js-support-message" class="support-message"></div>
 	<img src="images/soundwave.svg" role="presentation" class="soundwave" />
-	<script src="scripts/index.js"></script>	
+	<script src="scripts/index.js"></script>
 </body>
 </html>

--- a/speedreading/Default.html
+++ b/speedreading/Default.html
@@ -2,27 +2,27 @@
 <html lang="en">
 <head>
     <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
-    <!-- Demo Author: Jason Weber, Microsoft Corporation -->    
+    <!-- Demo Author: Jason Weber, Microsoft Corporation -->
     <title>HTML5 Speed Reading</title>
-    <meta name="description" content="Thanks for checking out this Internet Explorer 9 Platform Preview demo. This demo uses animation techniques to flip 96 letters as fast as possible." />    
-    <link rel="stylesheet" type="text/css" href="SpeedReading.css" />
+    <meta name="description" content="Thanks for checking out this Internet Explorer 9 Platform Preview demo. This demo uses animation techniques to flip 96 letters as fast as possible." />
+    <link rel="stylesheet" href="SpeedReading.css" />
     <meta name="t_omni_demopage" content="1" /><meta http-equiv="X-UA-Compatible" content="IE=edge" />
 </head>
 <body onload="Initialize()">
     <canvas id="surfaceCanvas"></canvas>
-    <div class="SRDescription">Thanks for checking out this Internet Explorer 9 Platform Preview demo. This demo uses animation techniques to flip 96 letters as fast as possible. The more powerful the underlying computer and the browser, the faster the images will flip. This demo uses HTML5 Canvas and HTML5 Audio. It's a fun way to demonstrate how Internet Explorer 9's overall performance, from hardware accelerated graphics, to compiled javascript, to hardware accelerated canvas, will enable a new generation of HTML5 applications. The purpose of these demos is to convey a concept and is not intended to be used as a best practice for web development. To start the test please press the (Enter) key a few seconds after the page loads. Enjoy!</div>    
+    <div class="SRDescription">Thanks for checking out this Internet Explorer 9 Platform Preview demo. This demo uses animation techniques to flip 96 letters as fast as possible. The more powerful the underlying computer and the browser, the faster the images will flip. This demo uses HTML5 Canvas and HTML5 Audio. It's a fun way to demonstrate how Internet Explorer 9's overall performance, from hardware accelerated graphics, to compiled javascript, to hardware accelerated canvas, will enable a new generation of HTML5 applications. The purpose of these demos is to convey a concept and is not intended to be used as a best practice for web development. To start the test please press the (Enter) key a few seconds after the page loads. Enjoy!</div>
     <audio id="SoundFlipRepeat" preload src="Sounds/FlipSoundRepeat.mp3"></audio>
     <audio id="SoundFlipSingle" preload src="Sounds/FlipSoundSingle.mp3"></audio>
-    <script type="text/javascript" src="../../Includes/Script/FeatureDetectCanvas.js"></script>
-    <script type="text/javascript" src="Script/Application.js"></script>
-    <script type="text/javascript" src="Script/EventHandlers.js"></script>
-    <script type="text/javascript" src="Script/Resources.js"></script>
-    <script type="text/javascript" src="Script/Billboard.js"></script>
-    <script type="text/javascript" src="Script/Patterns.js"></script>
-    <script type="text/javascript" src="Script/Tile.js"></script>
-    <script type="text/javascript" src="Script/Message.js"></script>
-    <script type="text/javascript" src="Script/Performance.js"></script>
-    <script type="text/javascript" src="../../includes/script/TestDriveCommon.js"></script>
-    <script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+    <script src="../../Includes/Script/FeatureDetectCanvas.js"></script>
+    <script src="Script/Application.js"></script>
+    <script src="Script/EventHandlers.js"></script>
+    <script src="Script/Resources.js"></script>
+    <script src="Script/Billboard.js"></script>
+    <script src="Script/Patterns.js"></script>
+    <script src="Script/Tile.js"></script>
+    <script src="Script/Message.js"></script>
+    <script src="Script/Performance.js"></script>
+    <script src="../../includes/script/TestDriveCommon.js"></script>
+    <script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
 </body>
 </html>

--- a/spellchecking/index.html
+++ b/spellchecking/index.html
@@ -6,8 +6,8 @@
 	<meta name="og:title" content="Spellchecking"/>
 	<meta name="description" content="Learn about Internet Explorer's support for spellchecking and how to use it"/>
 	<meta name="keywords" content="input, spellcheck, textarea, textbox, html5"/>
-	<link rel="stylesheet" type="text/css" href="styles/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="styles/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>
 <div class="container spellchecking-container">

--- a/sudoku/index.html
+++ b/sudoku/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="description" content="Test your skills with this full HTML5 Sudoku"/>
     <meta name="keywords" content="performance, javascript"/>
-    <link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+    <link rel="stylesheet" href="styles/demo.css"/>
     <link rel="shortcut icon" href="favicon.ico"/>
 </head>
 <body>
@@ -472,7 +472,7 @@
         </div>
 	</div>
 </div>
-<script type="text/javascript" src="scripts/demo.js">
+<script src="scripts/demo.js">
 </script>
 </body>
 </html>

--- a/svgradientbackgroundmaker/index.html
+++ b/svgradientbackgroundmaker/index.html
@@ -11,7 +11,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 
 	<link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
-	<link rel="stylesheet" type="text/css" href="styles/svgdemo.css"/>
+	<link rel="stylesheet" href="styles/svgdemo.css"/>
 </head>
 
 <body>
@@ -160,10 +160,10 @@
 			</section>
 		</article>
 
-<script type="text/javascript" src="scripts/svgdraw.js"></script>
-<script type="text/javascript" src="scripts/jscolor.js"></script>
-<script type="text/javascript" src="scripts/demo.js"></script>
-<script type="text/javascript" src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
+<script src="scripts/svgdraw.js"></script>
+<script src="scripts/jscolor.js"></script>
+<script src="scripts/demo.js"></script>
+<script src="https://msedgecdn.azurewebsites.net/scripts/demo-header.js"></script>
 </body>
 
 </html>

--- a/toucheffects/index.html
+++ b/toucheffects/index.html
@@ -8,7 +8,7 @@
 	<meta name="keywords" content="input"/>
 	<meta name="og:title" content="Touch Effects"/>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>
 	<canvas id="canvas"></canvas>
@@ -49,6 +49,6 @@
 	<img id="rainbow-strip" style="display: none;" alt="Rainbow Strip" src="images/rainbowstrip.png"/>
 	<img id="ball" style="display: none;" alt="Ball" src="images/ball.png"/>
 	<img id="circle" style="display: none;" alt="Circle" src="images/circle.png"/>
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 </html>

--- a/typedarrays/index.html
+++ b/typedarrays/index.html
@@ -11,7 +11,7 @@
 	<meta name="description" content="Read the file contents of a file using the File API, Blob and Typed Arrays"/>
 	<meta name="keywords"
 		  content="javascript, typed array, typedarrays, arrays, blob, Uint8Array, createObjectURL, fileAPI, filereader, html5,  es5, ecmascript, interoperability, "/>
-	<link rel="stylesheet" type="text/css" href="./styles/demo.css"/>
+	<link rel="stylesheet" href="./styles/demo.css"/>
 </head>
 
 <body>

--- a/userselect/index.html
+++ b/userselect/index.html
@@ -6,13 +6,13 @@
 	<title>User Selection via CSS</title>
 	<meta name="og:title" content="user select"/>
 	<meta name="keywords" content="input"/>
-	<link rel="stylesheet" type="text/css" href="styles/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/normal_off.css" id="normal_off_sheet" class="styles"/>
-	<link rel="stylesheet" type="text/css" href="styles/all_off.css" id="all_off_sheet" class="styles"/>
-	<link rel="stylesheet" type="text/css" href="styles/blog_only.css" id="blog_only_sheet" class="styles"/>
-	<link rel="stylesheet" type="text/css" href="styles/comments_only.css" id="comments_only_sheet" class="styles"/>
-	<link rel="stylesheet" type="text/css" href="styles/blog_beyond.css" id="blog_beyond_sheet" class="styles"/>
+	<link rel="stylesheet" href="styles/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
+	<link rel="stylesheet" href="styles/normal_off.css" id="normal_off_sheet" class="styles"/>
+	<link rel="stylesheet" href="styles/all_off.css" id="all_off_sheet" class="styles"/>
+	<link rel="stylesheet" href="styles/blog_only.css" id="blog_only_sheet" class="styles"/>
+	<link rel="stylesheet" href="styles/comments_only.css" id="comments_only_sheet" class="styles"/>
+	<link rel="stylesheet" href="styles/blog_beyond.css" id="blog_beyond_sheet" class="styles"/>
 </head>
 
 <body>
@@ -175,6 +175,6 @@
 		<br/>
 	</div>
 </div>
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 </html>

--- a/videoformatsupport/index.html
+++ b/videoformatsupport/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+<link rel="stylesheet" href="styles/demo.css"/>
 <div class="container videoformatsupport-container">
     <h1 id="demo-title">Video Format Support</h1>
 
@@ -71,7 +71,7 @@
         </p>
     </div>
 </div>
-<script type="text/javascript" src="scripts/demo.js"></script>
+<script src="scripts/demo.js"></script>
 </body>
 
 </html>

--- a/webaudiotuner/index.html
+++ b/webaudiotuner/index.html
@@ -5,8 +5,8 @@
 	<meta name="description" content="Chromatic tuner implemented using Web Audio and Media Stream APIs"/>
 	<meta name="keywords" content="Media, web audio"/>
 	<meta name="author" content="quimbs"/>
-	<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
 <body>
@@ -254,10 +254,10 @@
 		</div>
 	</section>
 
-<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
-<script type="text/javascript" src="scripts/demo.js"></script>
-<script type="text/javascript" src="https://bernii.github.io/gauge.js/dist/gauge.min.js"></script>
-<script type="text/javascript"
+<script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+<script src="scripts/demo.js"></script>
+<script src="https://bernii.github.io/gauge.js/dist/gauge.min.js"></script>
+<script
   src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 

--- a/webauthn/home.html
+++ b/webauthn/home.html
@@ -9,8 +9,8 @@
 <title>Sign in to your Microsoft account</title>
 
 <link href="images/favicon.png" rel="shortcut icon">
-<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-<link rel="stylesheet" type="text/css" href="css/style.css">
+<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+<link rel="stylesheet" href="css/style.css">
 
 </head>
 

--- a/webauthn/index.html
+++ b/webauthn/index.html
@@ -8,8 +8,8 @@
 	<title>Sign in to your Microsoft account</title>
 
 	<link href="images/favicon.png" rel="shortcut icon">
-	<link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-	<link rel="stylesheet" type="text/css" href="css/style.css">
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+	<link rel="stylesheet" href="css/style.css">
 
 </head>
 

--- a/webauthn/webauthnregister.html
+++ b/webauthn/webauthnregister.html
@@ -8,10 +8,10 @@
     <title>Sign in Successful</title>
 
     <link href="./images/favicon.png" rel="shortcut icon">
-    <link rel="stylesheet" type="text/css" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
-    <link rel="stylesheet" type="text/css" href="css/style.css">
+    <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css">
+    <link rel="stylesheet" href="css/style.css">
 
-    <script type="text/javascript"></script>
+    <script></script>
 
 </head>
 

--- a/webdriver/index.html
+++ b/webdriver/index.html
@@ -7,8 +7,8 @@
 	<meta name="description" content="Discover how WebDriver works in Microsoft Edge"/>
 	<meta name="keywords" content="WebDriver, Test Automation"/>
 	<meta name="author" content="instylevii"/>
-	<link rel="stylesheet" type="text/css" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
-	<link rel="stylesheet" type="text/css" href="styles/demo.css"/>
+	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>
 	<article class="content content--testdrive content--demo">
@@ -104,6 +104,6 @@
 			</section>
 		</div>
 	</article>
-	<script type="text/javascript" src="scripts/demo.js"></script>
+	<script src="scripts/demo.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The HTML specification defines default values for the `type` attribute for the `<script>`[<sup>[1]</sup>](#1) and `<style>`[<sup>[2]</sup>](#2) elements.

Browsers follow the specification so, unless a different value than the default is needed, the `type` attribute can be omitted, being redundant.

---

<a name="1"></a>[1]

  * https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type

     > Omitting the attribute, or setting it to a JavaScript MIME type, means that the script is a classic script, to be interpreted according to the JavaScript Script top-level production. Classic scripts are affected by the charset, async, and defer attributes. __Authors should omit the attribute, instead of redundantly giving a JavaScript MIME type.__ 

  * https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script

     > 6. If either:
     >
     >     * the `script` element has a `type` attribute and its value is the empty string, or
     >     * the `script` element has no `type` attribute but it has a `language` attribute and that attribute's value is the empty string, or
     >     * the `script` element has neither a `type` attribute nor a `language` attribute, then
     >
     >   ...let the script block's type string for this script element be `text/javascript`. "

<a name="2"></a>[2]

  * https://html.spec.whatwg.org/multipage/semantics.html#attr-style-type

    >The default value for the type attribute, which is used if the attribute is absent, is `text/css`.