### PR TITLE
Associate labels to their controls in Sudoku demo

### DIFF
--- a/sudoku/index.html
+++ b/sudoku/index.html
@@ -33,7 +33,7 @@
 
 					<!-- RAPID-SOLVE CONTROLS -->
 					<h2 class="subtitle">Rapid-solve games</h2>
-					<label for="games-quantity"># of games:</label>
+					<label for="games-quantity">>Number of Games:</label>
 					<div class="rapid-controls">
 						<select id="games-quantity">
 							<option value="1">1000</option>
@@ -46,7 +46,7 @@
 					<!-- RAPID-SOLVE STATUSES -->
 					<p id="calculating" hidden>Solving puzzles...</p>
 					<p id="finished-calculating" hidden>Finished in: <span id="time-finished"></span></p>
-					
+
 					<!-- THIS-GAME CONTROLS -->
 					<h2 class="subtitle">This game</h2>
 					<div class="actions">
@@ -68,7 +68,7 @@
 					</div>
 
 				</div>
-				
+
 				<div class="module module--primary">
 
 					<!-- SUDOKU BOARD -->


### PR DESCRIPTION
Fix MicrosoftEdge/Demos#235

<img src="https://cloud.githubusercontent.com/assets/1223565/21231047/954e273c-c2ef-11e6-9522-65f2fdc301b7.png" width=200>

---

Note: Removed `&nbsp;`s as they were adding extra nodes:

<img src="https://cloud.githubusercontent.com/assets/1223565/21231048/954e84e8-c2ef-11e6-80c2-5551473d9c30.png" width=200>