### PR TITLE
Make `a11y` related change for `eme` demo

### DIFF
--- a/eme/index.html
+++ b/eme/index.html
@@ -66,7 +66,7 @@
                                     <label for="bitrateSlider">Video Bitrate</label>
                                 </div>
                                 <div class="cell">
-                                    <input type="range" id="bitrateSlider" style="padding-top: 30px; padding-bottom: 30px;">
+                                    <input type="range" value="0" id="bitrateSlider" style="padding-top: 30px; padding-bottom: 30px;">
                                 </div>
                                 <div class="cell">
                                     <p id="bitrateLabel" class="label">0 kbps</p>

--- a/eme/index.html
+++ b/eme/index.html
@@ -63,7 +63,7 @@
                             <div class="controls">
                                 <video id="video" poster="images/Big_Buck_Bunny.jpg" controls></video>
                                 <div class="cell">
-                                    <p class="label">Video Bitrate</p>
+                                    <label for="bitrateSlider">Video Bitrate</label>
                                 </div>
                                 <div class="cell">
                                     <input type="range" id="bitrateSlider" style="padding-top: 30px; padding-bottom: 30px;">

--- a/eme/scripts/demo.js
+++ b/eme/scripts/demo.js
@@ -765,6 +765,7 @@
             bitrateSlider.value = bitrateSlider.max / 3;
             bitrateSlider.onchange = (function () {
                 var change = function () {
+                    bitrateSlider.setAttribute('value', bitrateSlider.value);
                     bitrateLabel.innerHTML = Math.round(manifest.videoStreams[bitrateSlider.value].bandwidth / 1000) + ' kbps';
                     player.setQualityLevel(0, bitrateSlider.value);
                 };
@@ -831,7 +832,6 @@
                 }
             }
         }
-        
     };
     gatherVideos();
 } ());

--- a/eme/styles/demo.css
+++ b/eme/styles/demo.css
@@ -74,16 +74,16 @@ div.cell {
     vertical-align: middle;
 }
 
+.cell label {
+    white-space: nowrap;
+    font-size: 12px;
+}
+
 input[type='range'] {
     width: 150px;
     height: auto;
     border: auto;
     padding: auto;
-}
-
-.label {
-    white-space: nowrap;
-    font-size: 12px;
 }
 
 .icon--link {


### PR DESCRIPTION
This should fix MicrosoftEdge/Demos/issues/241.

---

Changes:

* Use `<label>` instead of `<p>`.

* Add and sync `value` for `bitrateSlider`.

  > Another thing to note is the value should be kept in sync with the bitrate value after it. I'm skeptical this is the case as it has a max="7" applied to it, while bitrate goes up to 59999

    @dstorey The value basically [represents the level](https://github.com/MicrosoftEdge/Demos/blob/428c55490a2dc9144e0760a5d4651204bd9e6813/eme/scripts/demo.js#L768), and I made that sync. 

---

Notes: 
  
   * I haven't made any improvement, and respected the existing coding style .
   * haha @ [Not Your Father's Browser](https://vimeo.com/102845901)
