### PR TITLE
Remove `X-UA-Compatible` meta tags

### DIFF
--- a/analyzeperformance/index.html
+++ b/analyzeperformance/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Performance Examples</title>
 	<meta name="og:title" content="Performance Examples"/>
 	<meta name="description" content="A set of example pages to use for analyzing performance"/>

--- a/betafish/Default.html
+++ b/betafish/Default.html
@@ -3,7 +3,6 @@
     <head>
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>BetaFishIE</title>
         <meta name="description" content="HTML5 Fish, Touch and Performance Benchmark, HTML5 Test" />
         <link rel="image_src" href="../../Views/Homepage/Icons/BetaFishIE.png" />

--- a/blobbuilder/index.html
+++ b/blobbuilder/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Blob Bop</title>
 	<meta name="description" content="Create files dynamically on the client side using JavaScript and the Blob API"/>
 	<meta name="og:title" content="Blob Bop"/>

--- a/chalkboard/Default.html
+++ b/chalkboard/Default.html
@@ -3,7 +3,6 @@
     <head>
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>Chalkboard HTML5 Benchmark</title>
         <meta name="description" content="HTML5 and SVG Performance Benchmark" />
         <link rel="stylesheet" href="Chalkboard.css" />

--- a/editingpasteimage/index.html
+++ b/editingpasteimage/index.html
@@ -3,7 +3,6 @@
 <head>
 	<!-- Copyright Microsoft Corporation. All Rights Reserved. -->
 	<!-- Demo Author: Ben Peters, Microsoft Corporation -->
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<meta name="description" content="IE11 Paste Local Image Test Drive Demo" />
 	<title>Pasting Local Images Demo</title>
 	<link rel="stylesheet" href="styles/demo.css" />

--- a/eme/index.html
+++ b/eme/index.html
@@ -3,7 +3,6 @@
 
 <head>
     <title>Using Encrypted Media Extensions.</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="og:title" content="Using Playready content protection and other APIs to produce professional quality video."
     />
     <meta name="description" content="" />

--- a/fishbowlie/index.html
+++ b/fishbowlie/index.html
@@ -3,7 +3,6 @@
     <head>
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
-        <meta http-equiv="X-UA-Compatible" content="IE=10" />
         <title>HTML5 Fish Bowl</title>
 
         <meta name="description" content="Find your innner fish." />

--- a/fishietank/index.html
+++ b/fishietank/index.html
@@ -38,8 +38,8 @@
         }
 		div.control {
 		}
-    </style>    
-    <meta name="t_omni_demopage" content="1" /><meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    </style>
+    <meta name="t_omni_demopage" content="1" />
 </head>
 <body>
     <script>

--- a/html5forms/autofocus.html
+++ b/html5forms/autofocus.html
@@ -3,7 +3,6 @@
 <head>
     <meta name="description" content="IE10 Test Drive Demo"/>
     <meta name="t_omni_demopage" content="1"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
     <link rel="stylesheet" href="styles/demo.css"/>
 </head>

--- a/html5forms/index.html
+++ b/html5forms/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>HTML5 forms: Learn how to use the new attributes and input types in HTML5</title>
     <meta name="description"
           content="HTML5 Forms offers two major advantages over previous versions: new input types and built in validation. The form below is an example cake order form that utilizes validation and new input types."/>

--- a/letitsnow/Default.html
+++ b/letitsnow/Default.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="description" content="HTML5, Canvas, SVG, CSS3 and more!" />
     <meta name="t_omni_demopage" content="1" />
     <title>Let It Snow</title>    

--- a/mandelbrot/index.html
+++ b/mandelbrot/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Use JavaScript WebWorkers to increase the speed of your web applications</title>
 	<meta name="og:title" content="Mandelbrot WebWorkers"/>
 	<meta name="description"

--- a/mazesolver/Default.html
+++ b/mazesolver/Default.html
@@ -5,7 +5,7 @@
         <!-- Demo Author: Christian Stockwell, Microsoft Corporation -->        
 		<title>CSS Layout Performance Test</title>
 		<meta name="description" content="IE9 Test Drive Demo" />
-		<meta name="t_omni_demopage" content="1" /><meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="t_omni_demopage" content="1" />
 		<link rel="stylesheet" href="../Includes/Styles/BaseStyles.css" />
         <link rel="stylesheet" href="../Includes/Styles/ReturnAndShareControls.css" />
 		<link rel="shortcut icon" href="../Includes/Image/FavIcon.ico" />

--- a/particleacceleration/index.html
+++ b/particleacceleration/index.html
@@ -3,7 +3,6 @@
 <head>
 	<!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
 	<!-- Demo Authors: Jatinder Mann and Karlito Bonnevie, Microsoft Corporation -->
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Particle Acceleration</title>
 	<meta name="description"
 		  content="This demo uses mathematical models to draw the particles in 3D, using the 2D Context HTML5 Canvas. The faster your underlying browser and computer, the higher your score and faster the particles will spin."/>	

--- a/penguinmark/Default.html
+++ b/penguinmark/Default.html
@@ -3,7 +3,6 @@
     <head>
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>PenguinMark</title>
         <meta name="description" content="HTML5 Penguins, Performance, Web Benchmark, HTML5 Test" />
         <link rel="stylesheet" href="PenguinMark.css" />

--- a/photocapture/index.html
+++ b/photocapture/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
     <title>Photo Capture using Webcam</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta name="og:title" content="Photo Capture"/>
     <meta name="description" content="The test page demmonstartes how to use the Media Capture and Streams API
                                       to capture photos from webcam video streams through a canvas."/>

--- a/readingview/index.html
+++ b/readingview/index.html
@@ -5,7 +5,6 @@
     <!-- Bonnie Yu, Microsoft Corporation -->
     <!-- Credits go to Alex Gorbatchev for syntax highlighter javascript library -->
     <title>Reading View Guidelines</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="description"
           content="The Reading View Test Drive Demo provides guidelines on how developers can update website markup so the website renders great in Reading View."/>
     <!-- Used for live tile when site is pinned-->

--- a/setimmediatesorting/index.html
+++ b/setimmediatesorting/index.html
@@ -1,6 +1,5 @@
 <html lang="en">
 	<head>
-		<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 		<meta name="description" content="Compare the difference techniques for script yielding in JavaScript"/>
 		<meta name="keywords" content="performance, settimeout, setimmediate, yielding, javascript, es5, ecmascript"/>
 		<meta name="og:title" content="JavaScript yielding"/>

--- a/speedreading/Default.html
+++ b/speedreading/Default.html
@@ -6,7 +6,7 @@
     <title>HTML5 Speed Reading</title>
     <meta name="description" content="Thanks for checking out this Internet Explorer 9 Platform Preview demo. This demo uses animation techniques to flip 96 letters as fast as possible." />
     <link rel="stylesheet" href="SpeedReading.css" />
-    <meta name="t_omni_demopage" content="1" /><meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="t_omni_demopage" content="1" />
 </head>
 <body onload="Initialize()">
     <canvas id="surfaceCanvas"></canvas>

--- a/spellchecking/index.html
+++ b/spellchecking/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Spellchecking</title>
 	<meta name="og:title" content="Spellchecking"/>
 	<meta name="description" content="Learn about Internet Explorer's support for spellchecking and how to use it"/>

--- a/sudoku/index.html
+++ b/sudoku/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>HTML5 Sudoku</title>
     <meta name="og:title" content="HTML5 Sudoku"/>
     <meta http-equiv="Content-Language" content="en-us"/>

--- a/svgradientbackgroundmaker/index.html
+++ b/svgradientbackgroundmaker/index.html
@@ -8,7 +8,6 @@
 		  content="Use this demo to create SVG-based CSS background-image gradients. The CSS markup works in browsers which support SVG as a background-image including Internet Explorer 9, Chrome, Safari, and Opera."/>
 	<meta name="keywords" content="graphics, css"/>
 	<meta name="og:title" content="IE10 Test Drive Demo: SVG Gradient Background Maker"/>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 
 	<link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
 	<link rel="stylesheet" href="styles/svgdemo.css"/>

--- a/toucheffects/index.html
+++ b/toucheffects/index.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Touch Effects</title>
 	<meta name="description"
 		  content="This page contains a canvas element registered for DOM touch events. Special effects are applied in response to touch and gesture on the canvas. The buttons control simulation settings. This demo supports multitouch on Windows 8."/>
 	<meta name="keywords" content="input"/>
 	<meta name="og:title" content="Touch Effects"/>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 <body>

--- a/typedarrays/index.html
+++ b/typedarrays/index.html
@@ -5,7 +5,6 @@
 	<!-- Image from iStockphoto, 3dts, Sea composed by Binary code. -->
 	<!-- Video from iStockphoto, mindopen, Binary Code Impact. Loop. -->
 	<!-- Music from iStockphoto, WorkeGroup, Butterfly Lure. -->
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>TypedArrays, Blobs and binary inspection in HTML5</title>
 	<meta name="og:title" content="JavaScript TypedArrays"/>
 	<meta name="description" content="Read the file contents of a file using the File API, Blob and Typed Arrays"/>

--- a/userselect/index.html
+++ b/userselect/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<meta name="description" content="Fine-tune what and how users can select content in your website"/>
 	<title>User Selection via CSS</title>
 	<meta name="og:title" content="user select"/>

--- a/videoformatsupport/index.html
+++ b/videoformatsupport/index.html
@@ -7,7 +7,6 @@
     <meta name="keywords" content="media"/>
     <meta name="og:title" content="Video Format Support"/>
     <meta name="author" content="Microsoft Corporation, sarvaje"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 </head>
 
 <body>

--- a/webauthn/home.html
+++ b/webauthn/home.html
@@ -3,7 +3,6 @@
 
 
 <head>
-<meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
 <title>Sign in to your Microsoft account</title>

--- a/webauthn/index.html
+++ b/webauthn/index.html
@@ -2,7 +2,6 @@
 <html lang="en-us" dir="ltr">
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
 	<title>Sign in to your Microsoft account</title>

--- a/webauthn/webauthnregister.html
+++ b/webauthn/webauthnregister.html
@@ -2,7 +2,6 @@
 <html lang="en-us" dir="ltr">
 
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
     <title>Sign in Successful</title>


### PR DESCRIPTION
* [The `X-UA-Compatible` meta tag needs to be included before all other tags except for the `<title>` and the other `<meta>` tags](https://msdn.microsoft.com/en-us/library/jj676915.aspx). This isn't the case for most demos.

* Since the `X-UA-Compatible` HTTP header is sent, the meta tag isn't needed.

---

See also:

 * https://github.com/h5bp/html5-boilerplate/blob/41b63975e5bab30f8926148b43d0864c71f8f8a4/dist/doc/html.md#the-order-of-the-title-and-meta-tags