### PR TITLE
Declare the character encoding in HTML

### DIFF
--- a/analyzeperformance/index.html
+++ b/analyzeperformance/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Performance Examples</title>
 	<meta name="og:title" content="Performance Examples"/>

--- a/audiomixer/index.html
+++ b/audiomixer/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Microsoft Edge Audio Mixer</title>
 	<meta name="og:title" content="Microsoft Edge Audio Mixer"/>
 	<meta name="description" content="This application uses Web Audio to play sounds at specific points in time and IndexedDB to save and load songs and their settings."/>

--- a/betafish/Default.html
+++ b/betafish/Default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
         <meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/blobbuilder/index.html
+++ b/blobbuilder/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Blob Bop</title>
 	<meta name="description" content="Create files dynamically on the client side using JavaScript and the Blob API"/>

--- a/chalkboard/Default.html
+++ b/chalkboard/Default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
         <meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/coloringbook/index.html
+++ b/coloringbook/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <title>Web Note Coloring Book</title>
     <meta name="description" content="Web Note is a new feature of Microsoft Edge that helps you write, draw, make notes and share web pages.">
     <meta name="viewport" content="width=device-width">

--- a/compatinspector/index.html
+++ b/compatinspector/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Compat Inspector User Guide</title>
 	<meta name="og:title" content="Compat Inspector">
 	<meta name="description"

--- a/css3filters/index.html
+++ b/css3filters/index.html
@@ -1,5 +1,6 @@
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Learn how to use CSS3 Filters.</title>
 	<meta name="og:title" content="css3filters"/>
 	<meta name="description" content="Learn how to use CSS3 filters. "/>

--- a/css3mediaqueries/index.html
+++ b/css3mediaqueries/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+	<meta charset="utf-8">
 	<!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
 	<title>CSS3 Media Queries</title>
     <meta name="description" content="Introduced in IE9, CSS3 Media queries enable you to style a page based on different display surface factors such as width, height, orientation, resolution, etc." />

--- a/editingpasteimage/index.html
+++ b/editingpasteimage/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<!-- Copyright Microsoft Corporation. All Rights Reserved. -->
 	<!-- Demo Author: Ben Peters, Microsoft Corporation -->
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/eme/index.html
+++ b/eme/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <meta charset="utf-8">
     <title>Using Encrypted Media Extensions.</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="og:title" content="Using Playready content protection and other APIs to produce professional quality video."

--- a/familysearch/index.html
+++ b/familysearch/index.html
@@ -1,5 +1,6 @@
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Family-friendly web: safe searching</title>
 	<meta name="og:title" content="Family Friendly"/>
 	<meta name="description" content=""/>

--- a/fishbowlie/index.html
+++ b/fishbowlie/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
         <meta http-equiv="X-UA-Compatible" content="IE=10" />

--- a/fishietank/index.html
+++ b/fishietank/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
 
     <title>FishIE Tank</title>

--- a/html5forms/index.html
+++ b/html5forms/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>HTML5 forms: Learn how to use the new attributes and input types in HTML5</title>
     <meta name="description"

--- a/letitsnow/Default.html
+++ b/letitsnow/Default.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="description" content="HTML5, Canvas, SVG, CSS3 and more!" />
     <meta name="t_omni_demopage" content="1" />

--- a/mandelbrot/index.html
+++ b/mandelbrot/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Use JavaScript WebWorkers to increase the speed of your web applications</title>
 	<meta name="og:title" content="Mandelbrot WebWorkers"/>

--- a/math/index.html
+++ b/math/index.html
@@ -1,5 +1,6 @@
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Precision of new Math APIs</title>
 	<meta name="og:title" content="maqth"/>
 	<meta name="description" content=""/>

--- a/mazesolver/Default.html
+++ b/mazesolver/Default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Christian Stockwell, Microsoft Corporation -->        
 		<title>CSS Layout Performance Test</title>

--- a/microphone/index.html
+++ b/microphone/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Microphone Demo</title>
 	<meta name="og:title" content="microphone"/>
 	<meta name="description" content=""/>

--- a/musiclounge/index.html
+++ b/musiclounge/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<meta charset="utf-8">
 		<title>Learn how to use WebAudio, WebGL and pointer events thanks to Babylon.js</title>
 		<meta name="og:title" content="Music Lounge" />
 		<meta name="description" content="Music Lounge is an interactive demo that showcase WebGL audio positioning within a minimalistic UI based on babylon.js" />

--- a/particleacceleration/index.html
+++ b/particleacceleration/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
 	<!-- Demo Authors: Jatinder Mann and Karlito Bonnevie, Microsoft Corporation -->
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/penguinmark/Default.html
+++ b/penguinmark/Default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
         <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
         <!-- Demo Author: Jason Weber, Microsoft Corporation -->
         <meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/photocapture/index.html
+++ b/photocapture/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <title>Photo Capture using Webcam</title>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta name="og:title" content="Photo Capture"/>

--- a/readingview/index.html
+++ b/readingview/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
     <!-- Bonnie Yu, Microsoft Corporation -->
     <!-- Credits go to Alex Gorbatchev for syntax highlighter javascript library -->

--- a/setimmediatesorting/index.html
+++ b/setimmediatesorting/index.html
@@ -1,5 +1,6 @@
 <html lang="en">
 	<head>
+		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 		<meta name="description" content="Compare the difference techniques for script yielding in JavaScript"/>
 		<meta name="keywords" content="performance, settimeout, setimmediate, yielding, javascript, es5, ecmascript"/>

--- a/speechsynthesis/index.html
+++ b/speechsynthesis/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<title>Speech Synthesis Demo</title>
 	<meta name="description" content="Enter text and play it back as speech with different voices and settings">
 	<meta name="keywords" content="speech, synthesis, text-to-speech, SSML">

--- a/speedreading/Default.html
+++ b/speedreading/Default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <!-- Copyright © Microsoft Corporation. All Rights Reserved. -->
     <!-- Demo Author: Jason Weber, Microsoft Corporation -->
     <title>HTML5 Speed Reading</title>

--- a/spellchecking/index.html
+++ b/spellchecking/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Spellchecking</title>
 	<meta name="og:title" content="Spellchecking"/>

--- a/sudoku/index.html
+++ b/sudoku/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>HTML5 Sudoku</title>
     <meta name="og:title" content="HTML5 Sudoku"/>
     <meta http-equiv="Content-Language" content="en-us"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="description" content="Test your skills with this full HTML5 Sudoku"/>
     <meta name="keywords" content="performance, javascript"/>
     <link rel="stylesheet" href="styles/demo.css"/>

--- a/svgradientbackgroundmaker/index.html
+++ b/svgradientbackgroundmaker/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<!-- Credits: jscolor, by Jan Odvarko (http://odvarko.cz) -->
 	<!-- Credits: base-64 URL encoder/decoder, by webtoolkit (http://www.webtoolkit.info/javascript-base64.html) -->
 	<title>IE10 Test Drive Demo: SVG Gradient Background Maker</title>

--- a/toucheffects/index.html
+++ b/toucheffects/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<title>Touch Effects</title>
 	<meta name="description"

--- a/typedarrays/index.html
+++ b/typedarrays/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<!-- Image from iStockphoto, loops7, binary code and computer monitors. -->
 	<!-- Image from iStockphoto, 3dts, Sea composed by Binary code. -->
 	<!-- Video from iStockphoto, mindopen, Binary Code Impact. Loop. -->

--- a/userselect/index.html
+++ b/userselect/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	<meta name="description" content="Fine-tune what and how users can select content in your website"/>
 	<title>User Selection via CSS</title>

--- a/videoformatsupport/index.html
+++ b/videoformatsupport/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <!-- Copyright Microsoft Corporation. All Rights Reserved. -->
     <title>Video Format Support</title>
     <meta name="description" content="This demonstration shows which video format(s) your browser is able to play."/>

--- a/webaudiotuner/index.html
+++ b/webaudiotuner/index.html
@@ -1,5 +1,6 @@
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>Web Audio Tuner</title>
 	<meta name="og:title" content="Web Audio tuner"/>
 	<meta name="description" content="Chromatic tuner implemented using Web Audio and Media Stream APIs"/>

--- a/webauthn/home.html
+++ b/webauthn/home.html
@@ -3,8 +3,8 @@
 
 
 <head>
+<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
 <title>Sign in to your Microsoft account</title>
 

--- a/webauthn/index.html
+++ b/webauthn/index.html
@@ -2,8 +2,8 @@
 <html lang="en-us" dir="ltr">
 
 <head>
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
 	<title>Sign in to your Microsoft account</title>
 

--- a/webauthn/webauthnregister.html
+++ b/webauthn/webauthnregister.html
@@ -2,8 +2,8 @@
 <html lang="en-us" dir="ltr">
 
 <head>
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
     <title>Sign in Successful</title>
 


### PR DESCRIPTION
These additions are done because the demos should not assume that the server will send a certain HTTP header / header value (e.g.: `Content-Type:"text/html; charset=utf-8"`).

From https://github.com/MicrosoftEdge/Demos/pull/266#issuecomment-268756051:

> "_demos can be consumed in another way (we could move the Demos to another domain, run from http-server, etc.) so we shouldn't assume that the server is always going to add it"_ (it = HTTP header)

Without the charset parameter in the `Content-Type` HTTP header header and the meta `charset`, some of the demos (e.g.:  [`Let it snow`](https://developer.microsoft.com/en-us/microsoft-edge/testdrive/demos/letitsnow/)), will even trigger, in Firefox for example, a warning:

![screen shot 2016-12-22 at 15 12 18](https://cloud.githubusercontent.com/assets/1223565/21426715/23b6d9c4-c859-11e6-80fe-5ece1fb4bb5c.png)

---

Changes:

* Where missing, add the charset declaration.

  Note: The charset declaration should be specified as early as possible, and [must be included completely within the first 1024 bytes of the document](https://html.spec.whatwg.org/multipage/semantics.html#charset).

* [Use `<meta charset="utf-8">` instead of `<meta http-equiv="content-type" content="text/html; charset=utf-8"/>`](https://blog.whatwg.org/the-road-to-html-5-character-encoding).

See also:

  * https://www.w3.org/International/questions/qa-html-encoding-declarations.en
  * https://www.w3.org/International/articles/http-charset/