### PR TITLE
Hide `Test Your Browser` button in `PenguinMark` demo visually, but also from screen readers

### DIFF
--- a/penguinmark/Script/Application.js
+++ b/penguinmark/Script/Application.js
@@ -1,4 +1,4 @@
-﻿var SINGLE_CYCLE = 16.7;
+var SINGLE_CYCLE = 16.7;
 
 var debug = false, started = false;
 var sceneLeft, sceneTop, sceneWidth, sceneHeight;
@@ -36,9 +36,13 @@ function ResizeScene() {
 }
 
 function StartPenguinMark() {
+
+    var welcomeScreen = document.getElementById("WelcomeScreen");
+
     if (started == false) {
         started = true;
-        document.getElementById("WelcomeScreen").style.opacity = 0;
+        welcomeScreen.style.display = "none";
+        welcomeScreen.setAttribute("aria-hidden", "true");
         document.getElementById("AudioEntryElement").pause();
         document.getElementById("AudioTrackElement").play();
         characters.Start();


### PR DESCRIPTION
Once the `Test Your Browser` button is pressed, hide it visually, but also from screen readers.