### PR TITLE
Add better labels for buttons in `Audio Tuner` demo

### DIFF
--- a/webaudiotuner/index.html
+++ b/webaudiotuner/index.html
@@ -6,7 +6,7 @@
 	<meta name="description" content="Chromatic tuner implemented using Web Audio and Media Stream APIs"/>
 	<meta name="keywords" content="Media, web audio"/>
 	<meta name="author" content="quimbs"/>
-	<link rel="stylesheet" href="//edgeportal.blob.core.windows.net/media/demotemplate.css"/>
+	<link rel="stylesheet" href="https://edgeportal.blob.core.windows.net/media/demotemplate.css"/>
 	<link rel="stylesheet" href="styles/demo.css"/>
 </head>
 
@@ -55,34 +55,34 @@
 					<div class="tuner__controls">
 						<h3 class="subtitle">Tune using:</h3>
 						<div class="actions">
-	                    	<button class="button tuner__input-button" id="micButton">Microphone</button>
-	                    	<button class="button tuner__input-button" id="refButton">Reference tone</button>
+							<button class="button tuner__input-button" id="micButton">Microphone</button>
+							<button class="button tuner__input-button" id="refButton">Reference tone</button>
 						</div>
-	                    <div id="microphoneOptions" class="tuner__options">
-	                        <fieldset>
-	                            <legend class="subtitle">Base frequency</legend>
+						<div id="microphoneOptions" class="tuner__options">
+							<fieldset>
+								<legend id="micBaseFreq" class="subtitle">Base frequency</legend>
 								<div class="actions">
-									<button class="button tuner__options__button minusFreq">-</button>
-									<button class="button tuner__options__button plusFreq">+</button>
+									<button id="micDecreaseBaseFreqButton" class="button tuner__options__button minusFreq" aria-label="decrease" aria-labelledby="micDecreaseBaseFreqButton micButton micBaseFreq">-</button>
+									<button id="micIncreaseBaseFreqButton" class="button tuner__options__button plusFreq" aria-label="increase" aria-labelledby="micIncreaseBaseFreqButton micButton micBaseFreq">+</button>
 								</div>
-	                        </fieldset>
-	                    </div>
-	                    <div id="referenceOptions" class="tuner__options">
-	                        <fieldset>
-	                            <legend class="subtitle">Base frequency</legend>
+							</fieldset>
+						</div>
+						<div id="referenceOptions" class="tuner__options">
+							<fieldset>
+								<legend id="refBaseFreq" class="subtitle">Base frequency</legend>
 								<div class="actions">
-									<button class="button tuner__options__button minusFreq">-</button>
-									<button class="button tuner__options__button plusFreq">+</button>
+									<button id="refDecreaseBaseFreqButton" class="button tuner__options__button minusFreq" aria-label="decrease" aria-labelledby="refDecreaseBaseFreqButton refButton refBaseFreq">-</button>
+									<button id="refIncreaseBaseFreqButton" class="button tuner__options__button plusFreq" aria-label="increase" aria-labelledby="refIncreaseBaseFreqButton refButton refBaseFreq">+</button>
 								</div>
-	                        </fieldset>
-	                        <fieldset>
-	                            <legend class="subtitle">Note</legend>
+							</fieldset>
+							<fieldset>
+								<legend id="refNote" class="subtitle">Note</legend>
 								<div class="actions">
-									<button class="button tuner__options__button" id="minusRefNote">-</button>
-									<button class="button tuner__options__button" id="plusRefNote">+</button>
+									<button id="refDecreaseNoteButton" class="button tuner__options__button" aria-label="decrease" aria-labelledby="refDecreaseNoteButton refButton refNote">-</button>
+									<button id="refIncreaseNoteButton" class="button tuner__options__button" aria-label="increase" aria-labelledby="refIncreaseNoteButton refButton refNote">+</button>
 								</div>
-	                        </fieldset>
-	                    </div>
+							</fieldset>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -258,8 +258,7 @@
 <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
 <script src="scripts/demo.js"></script>
 <script src="https://bernii.github.io/gauge.js/dist/gauge.min.js"></script>
-<script
-  src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 
 </body>

--- a/webaudiotuner/scripts/demo.js
+++ b/webaudiotuner/scripts/demo.js
@@ -311,8 +311,8 @@ $(document).ready(function () {
 	$('#micButton').click(toggleMicrophone);
 	$('.minusFreq').click(-2, baseFreqChangeHandler);
 	$('.plusFreq').click(2, baseFreqChangeHandler);
-	$('#minusRefNote').click(-1, referenceSoundNoteHandler);
-	$('#plusRefNote').click(1, referenceSoundNoteHandler);
+	$('#refDecreaseNoteButton').click(-1, referenceSoundNoteHandler);
+	$('#refIncreaseNoteButton').click(1, referenceSoundNoteHandler);
 
 	init();
 });

--- a/webaudiotuner/styles/demo.css
+++ b/webaudiotuner/styles/demo.css
@@ -2,6 +2,11 @@
 	margin-top: 2.4rem;
 }
 
+#microphoneOptions,
+#referenceOptions {
+	display: none;
+}
+
 .section--tuner {
 	padding: 4.8rem 0;
 	background: #f2f2f2;
@@ -38,7 +43,7 @@
 }
 
 .tuner__options__button {
-	min-width: 3rem;	
+	min-width: 3rem;
 }
 
 fieldset {
@@ -61,6 +66,5 @@ blockquote {
 		padding-top: 0;
 		border-top: 0 none;
 	}
-	
 
 }


### PR DESCRIPTION
Fix MicrosoftEdge/Demos#242

---

@dstorey I decided to go with, for example, _"increase microphone base frequency"_ instead of [the suggested](https://github.com/MicrosoftEdge/Demos/issues/242#issue-195704514) _"increase base frequency"_ as it seemed more clear to me. 

Let me know if you want that changed!