### PR TITLE
Make MathML examples from `Web Audio tuner` demo visible

### DIFF
--- a/webaudiotuner/styles/demo.css
+++ b/webaudiotuner/styles/demo.css
@@ -3,7 +3,7 @@
 }
 
 /*
-	The following is done so that the MathML examples remain visible.
+	@Bug: The following is done so that the MathML examples remain visible.
 	https://github.com/MicrosoftEdge/Demos/issues/328#issuecomment-269772211
 */
 

--- a/webaudiotuner/styles/demo.css
+++ b/webaudiotuner/styles/demo.css
@@ -2,6 +2,15 @@
 	margin-top: 2.4rem;
 }
 
+/*
+	The following is done so that the MathML examples remain visible.
+	https://github.com/MicrosoftEdge/Demos/issues/328#issuecomment-269772211
+*/
+
+[aria-hidden="true"] {
+	display: inline;
+}
+
 #microphoneOptions,
 #referenceOptions {
 	display: none;
@@ -55,8 +64,8 @@ fieldset {
 
 blockquote {
 	margin-right: 8%;
-    margin-left: 8%;
-    font-style: italic;
+	margin-left: 8%;
+	font-style: italic;
 }
 
 @media (min-width: 48em) {


### PR DESCRIPTION
Ref: https://github.com/MicrosoftEdge/Demos/issues/328#issuecomment-269772211
Fix: MicrosoftEdge/Demos#328