### PR TITLE
Add link to `Can I Use` in `PaymentrRequest` demo

### DIFF
--- a/paymentrequest/index.html
+++ b/paymentrequest/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-US">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<title>Getting Started With PaymentRequest</title>
 	<meta name="keywords" content="W3C Payment Request API, Web Payments, tutorial, samples">
 	<meta name="description" content="Getting started with the W3C Payment Request API">

--- a/paymentrequest/scripts/index.js
+++ b/paymentrequest/scripts/index.js
@@ -37,7 +37,7 @@ addEventListener('load', function() {
 	//Show message if the browser supports the Payment Request API
 	if (!('PaymentRequest' in window)) {
 		warning.style.display = '';
-		warning.innerHTML = '<p>This browser does not support web payments. You should try the <a href="https://microsoft.com/windows/microsoft-edge">Microsoft Edge</a> browser!</p>';
+		warning.innerHTML = 'This browser does not support web payments. You should try <a href="https://microsoft.com/windows/microsoft-edge">Microsoft Edge</a>, or <a href="http://caniuse.com/#search=Payment%20Request%20API">other browsers</a> that support them.';
 	}
 
 	var shippingOptionChangeHandlerString = '\n\nvar onShippingOptionChange = ' + normalize(Global.onShippingOptionChange, 2) + ';',


### PR DESCRIPTION
## What this PR does

In the message shown to users that visit the page from browsers that do not support the `Payment Request API`, include a link to the related `Can I Use` page in order to further indicate that this API
is not proprietary and is supported also in other browsers.

![](https://cloud.githubusercontent.com/assets/1223565/22506866/63150efe-e88b-11e6-9637-1dd8a1d1d50a.png)


## Requirements

* [x] My PR follows all applicable accessibility requirements (See `/.github/ACCESSIBILITY_REQS.md`)