### PR TITLE
Fix EME demo for video freezing after switching to >= 4x playback rate.

### DIFF
--- a/eme/scripts/demo.js
+++ b/eme/scripts/demo.js
@@ -311,7 +311,12 @@
                 this.sendMediaSegment();
                 return;
             }
-            if (this.vid.currentTime + this.MAX_BUFFER <= end) {
+            var maxBuffer = this.MAX_BUFFER;
+            if (this.vid.playbackRate > 1) {
+                maxBuffer *= this.vid.playbackRate;
+            }
+
+            if (this.vid.currentTime + maxBuffer <= end) {
                 return;
             }
             this.appending = true;


### PR DESCRIPTION
fixes #393 

## What this PR does

@molant 

Fix bug where higher playback rates may not buffer up enough data to fill the decoder's pipeline, especially if the source is dropping everything except key frames.

Fix is to increase the MAX_BUFFER read-ahead buffer for rates greater than 1x.

## Requirements

* [X] My PR follows all applicable accessibility requirements (See [`.github/ACCESSIBILITY_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/ACCESSIBILITY_REQS.md)).
* [X] My PR follows the CSS code style guidelines (See [`.github/CSS_STYLE_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/CSS_STYLE_REQS.md)).
* [X] I have linted my code using `npm run lint:css -- demoDirectoryName/**/*.css` and `npm run lint:js -- demoDirectoryName/**/*.js`, and have fixed the errors.