### PR TITLE
Use new "supportedMethods" format (string rather than array) in PaymentRequest

### DIFF
--- a/paymentrequest/scripts/samples.js
+++ b/paymentrequest/scripts/samples.js
@@ -76,11 +76,8 @@
 
 	Global.startPaymentRequestStaticShipping = function() {
 		const methodData = [
-			//Older implementation (for some versions of Chrome on Android)
-			{supportedMethods: ['visa', 'mastercard', 'amex']},
-			//Newer implementation
 			{
-				supportedMethods: ['basic-card'],
+				supportedMethods: 'basic-card',
 				data: {
 					supportedNetworks: ['visa', 'mastercard', 'amex'],
 					supportedTypes: ['credit']
@@ -149,11 +146,8 @@
 
 	Global.startPaymentRequestDynamicShipping = function() {
 		const methodData = [
-			//Older implementation
-			{supportedMethods: ['visa', 'mastercard', 'amex']},
-			//Newer implementation
 			{
-				supportedMethods: ['basic-card'],
+				supportedMethods: 'basic-card',
 				data: {
 					supportedNetworks: ['visa', 'mastercard', 'amex'],
 					supportedTypes: ['credit']
@@ -216,11 +210,8 @@
 
 	Global.startPaymentRequestDigitalMerchandise = function() {
 		const methodData = [
-			//Older implementation
-			{supportedMethods: ['visa', 'mastercard', 'amex']},
-			//Newer implementation
 			{
-				supportedMethods: ['basic-card'],
+				supportedMethods: 'basic-card',
 				data: {
 					supportedNetworks: ['visa', 'mastercard', 'amex'],
 					supportedTypes: ['credit']
@@ -263,7 +254,7 @@
 
 	Global.startPaymentRequestWithContactInfo = function() {
 		const methodData = [{
-			supportedMethods: ['visa', 'mastercard', 'amex'],
+			supportedMethods: 'basic-card',
 			data: {
 				supportedNetworks: ['visa', 'mastercard', 'amex'],
 				supportedTypes: ['credit']


### PR DESCRIPTION
## What this PR does
The `PaymentRequest` demo uses an old format for the `supportedMethods` property inside `methodData`, which breaks new implementations which rely on this property being a **String**, not an **Array**. Therefore, I replaced this parameter to follow the [current specs](https://w3c.github.io/payment-request/#x4-paymentmethoddata-dictionary).

## Requirements

* [x] My PR follows all applicable accessibility requirements (See [`.github/ACCESSIBILITY_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/ACCESSIBILITY_REQS.md)).
* [x] My PR follows the CSS code style guidelines (See [`.github/CSS_STYLE_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/CSS_STYLE_REQS.md)).
* [x] I have linted my code using `npm run lint:css -- demoDirectoryName/**/*.css` and `npm run lint:js -- demoDirectoryName/**/*.js`, and have fixed the errors.