### PR TITLE
Fix: Resume `audioContext` after user interaction

### DIFF
--- a/webaudiotuner/scripts/demo.js
+++ b/webaudiotuner/scripts/demo.js
@@ -218,6 +218,9 @@ $(document).ready(function () {
 	};
 
 	var toggleMicrophone = function () {
+		if (audioContext.state === 'suspended') { 	
+			audioContext.resume(); 
+		}
 		if (isRefSoundPlaying) {
 			turnOffReferenceSound();
 		}
@@ -251,6 +254,9 @@ $(document).ready(function () {
 	};
 
 	var toggleReferenceSound = function () {
+		if (audioContext.state === 'suspended') { 	
+			audioContext.resume(); 
+		} 
 		if (isMicrophoneInUse) {
 			toggleMicrophone();
 		}


### PR DESCRIPTION
@molant 

## What this PR does
Because of the AutoPlay policy changes the AudioContext is in suspended state by default (https://developers.google.com/web/updates/2017/09/autoplay-policy-changes). It can be resumed after a user interaction. That's what my fix is doing, its resuming the AudioContext after the user is clicking on the 'Microphone' or 'Reference tone' buttons.

## Requirements

* [x] My PR follows all applicable accessibility requirements (See [`.github/ACCESSIBILITY_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/ACCESSIBILITY_REQS.md)).
* [x] My PR follows the CSS code style guidelines (See [`.github/CSS_STYLE_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/CSS_STYLE_REQS.md)).
* [x] I have linted my code using `npm run lint:css -- demoDirectoryName/**/*.css` and `npm run lint:js -- demoDirectoryName/**/*.js`, and have fixed the errors.