### PR TITLE
Dont repeat voices in speechsynthesis demo

### DIFF
--- a/speechsynthesis/scripts/index.js
+++ b/speechsynthesis/scripts/index.js
@@ -37,7 +37,7 @@
 		while (selectObject.length > 0) {
 			selectObject.remove(selectObject.length - 1);
 		}
-	}
+	};
 
 	// Clear combobox then add voice options
 	const displayVoices = function(voices) {
@@ -48,7 +48,7 @@
 			option.innerHTML = voice.name;
 			voiceSelect.appendChild(option);
 		});
-	}
+	};
 
 	// Loading available voices for this browser/platform
 	// And displaying them into the combobox

--- a/speechsynthesis/scripts/index.js
+++ b/speechsynthesis/scripts/index.js
@@ -32,17 +32,32 @@
 		supportMessageEle.classList.add('unSupported');
 	}
 
-	// Loading available voices for this browser/platform
-	// And displaying them into the combobox
-	const loadVoices = function () {
-		const voices = speechSynthesis.getVoices();
+	// Generic function to remove all options from a select
+	const clearSelect = function(selectObject) {
+		while (selectObject.length > 0) {
+			selectObject.remove(selectObject.length - 1);
+		}
+	}
 
+	// Clear combobox then add voice options
+	const displayVoices = function(voices) {
+		clearSelect(voiceSelect);
 		voices.forEach((voice) => {
 			const option = document.createElement('option');
 			option.value = voice.name;
 			option.innerHTML = voice.name;
 			voiceSelect.appendChild(option);
 		});
+	}
+
+	// Loading available voices for this browser/platform
+	// And displaying them into the combobox
+	const loadVoices = function () {
+		const voices = speechSynthesis.getVoices();
+
+		if (voices.length > 0) {
+			displayVoices(voices);
+		}
 	};
 
 	const speak = function (textToSpeech) {


### PR DESCRIPTION
## What this PR does
Makes it so the select element in the speechsynthesis demo is cleared every time loadVoices is called. Previously the code was not clearing the box, which caused the list to repeat voices. @molant 
## Requirements

* [NA] My PR follows all applicable accessibility requirements (See [`.github/ACCESSIBILITY_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/ACCESSIBILITY_REQS.md)).
* [NA] My PR follows the CSS code style guidelines (See [`.github/CSS_STYLE_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/CSS_STYLE_REQS.md)).
* [Y] I have linted my code using `npm run lint:css -- demoDirectoryName/**/*.css` and `npm run lint:js -- demoDirectoryName/**/*.js`, and have fixed the errors.