### PR TITLE
/variable-fonts/LICENSE.MD Updated

### DIFF
--- a/variable-fonts/LICENSE.MD
+++ b/variable-fonts/LICENSE.MD
@@ -12,4 +12,4 @@ Intersection Observor Polyfill
 
 Decovar Font
 -------------------------------
-Copyright TypeNetwork by David Berlow
+[Decovar](https://github.com/TypeNetwork/Decovar) was designed by David Berlow, and is available under the [SIL Open Font License](https://github.com/TypeNetwork/Decovar/blob/master/LICENSE.txt).


### PR DESCRIPTION
## What this PR does

Improves attribution and states the license of Decovar font


## Requirements

* [x] My PR follows all applicable accessibility requirements (See [`.github/ACCESSIBILITY_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/ACCESSIBILITY_REQS.md)).
* [x] My PR follows the CSS code style guidelines (See [`.github/CSS_STYLE_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/CSS_STYLE_REQS.md)).
* [x] I have linted my code using `npm run lint:css -- demoDirectoryName/**/*.css` and `npm run lint:js -- demoDirectoryName/**/*.js`, and have fixed the errors.