### PR TITLE
Added charLength and name to SpeechSynthesisEvent console.log

### DIFF
--- a/speechsynthesis/scripts/index.js
+++ b/speechsynthesis/scripts/index.js
@@ -84,7 +84,7 @@
 		const eventList = ['start', 'end', 'mark', 'pause', 'resume', 'error', 'boundary'];
 		eventList.forEach((event) => {
 			synUtterance.addEventListener(event, (speechSynthesisEvent) => {
-				log(`Fired '${speechSynthesisEvent.type}' event at time '${speechSynthesisEvent.elapsedTime}' and character '${speechSynthesisEvent.charIndex}'.`);
+				log(`Fired '${speechSynthesisEvent.type}' event named '${speechSynthesisEvent.name}' at time '${speechSynthesisEvent.elapsedTime}' and character '${speechSynthesisEvent.charIndex} of length '${speechSynthesisEvent.charLength}.`);
 			});
 		});
 


### PR DESCRIPTION
## What this PR does
Makes it so that the name and charLength fields of a SpeechSynthesisEvent are printed to the console when an event occurs. @molant 
## Requirements
*Note: My PR does not add any *new* UI, it just prints more text to the console. I believe this is outside of the accessibility requirements.
* [NA ] My PR follows all applicable accessibility requirements (See [`.github/ACCESSIBILITY_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/ACCESSIBILITY_REQS.md)).
* [NA ] My PR follows the CSS code style guidelines (See [`.github/CSS_STYLE_REQS.md`](https://github.com/MicrosoftEdge/Demos/blob/master/.github/CSS_STYLE_REQS.md)).
* [x] I have linted my code using `npm run lint:css -- demoDirectoryName/**/*.css` and `npm run lint:js -- demoDirectoryName/**/*.js`, and have fixed the errors.